### PR TITLE
Clean up Text for QEO_SUPPORT

### DIFF
--- a/quic-encryption-offload.md
+++ b/quic-encryption-offload.md
@@ -69,23 +69,12 @@ typedef enum _QEO_SUPPORT_FLAGS {
 } QEO_SUPPORT_FLAGS;
 ```
 
-### Values
-
-#### QEO_SUPPORT_FLAG_AEAD_AES_128_GCM
-
-This bit indicates the AEAD_AES_128_GCM cryptographic algorithm is supported.
-
-#### QEO_SUPPORT_FLAG_AEAD_AES_256_GCM
-
-This bit indicates the AEAD_AES_256_GCM cryptographic algorithm is supported.
-
-#### QEO_SUPPORT_FLAG_AEAD_CHACHA20_POLY1305
-
-This bit indicates the AEAD_CHACHA20_POLY1305 cryptographic algorithm is supported.
-
-#### QEO_SUPPORT_FLAG_AEAD_AES_128_CCM
-
-This bit indicates the AEAD_AES_128_CCM cryptographic algorithm is supported.
+Value | Meaning
+--- | ---
+**QEO_SUPPORT_FLAG_AEAD_AES_128_GCM**<br> | The AEAD_AES_128_GCM cryptographic algorithm is supported.
+**QEO_SUPPORT_FLAG_AEAD_AES_256_GCM**<br> | The AEAD_AES_256_GCM cryptographic algorithm is supported.
+**QEO_SUPPORT_FLAG_AEAD_CHACHA20_POLY1305**<br> | The AEAD_CHACHA20_POLY1305 cryptographic algorithm is supported.
+**QEO_SUPPORT_FLAG_AEAD_AES_128_CCM**<br> | The AEAD_AES_128_CCM cryptographic algorithm is supported.
 
 ### Return value
 


### PR DESCRIPTION
I removed the socket layer capability flags for TX and RX with the assumption that they will both always be supported in SW fallback. Please let me know if you disagree.