### PR TITLE
Remove Nonsequential Packet TODO

### DIFF
--- a/quic-encryption-offload.md
+++ b/quic-encryption-offload.md
@@ -303,8 +303,6 @@ If a QEO packet is posted and no matching encryption parameters are established,
 
 > **TODO -** Explicitly mention that usage of QEO with USO must be supported.
 
-> **TODO -** What about nonsequential packets? If we’re just passing a `NextPacketNumber` then how will that work?
-
 
 ## Receiving Packets
 


### PR DESCRIPTION
This TODO is unnecessary because the NextPacketNumber is just the fully expanded packet number and doesn't strictly need to be the next. From this value you can calculate the full packet numbers of all packets being sent. This comes from a requirement in the QUIC protocol itself, because the receiver has to be able to decode the compressed packet numbers too, in order to decrypt the packets.

I don't think we need to state anything here.