### PR TITLE
Stateful Packet Number Changes

### DIFF
--- a/quic-encryption-offload.md
+++ b/quic-encryption-offload.md
@@ -229,6 +229,7 @@ To simplify the interface at the socket layer, TCPIP will support the SW fallbac
 To support SW fallback, the following will have to be added to TCPIP:
 
 - All offload state must be mirrored in TCPIP.
+- TCPIP must keep the packet number state up to date so long as the connection is offloaded, by inspecting packets numbers sent and received on the datapath.
 - Support capabilities can only be advertised for features that can be implemented in software. Any missing SW features (e.g. ChaCha20-Poly1305) cannot be advertised, even if the HW supports it.
 - In addition to the offloaded connection state passed by the app, TCPIP must also track if the state has been successfully offloaded to the NIC.
 - When an app offloads a connection, it should first go into the local mirror (synchronously) and then be offloaded to the NIC (likely async).


### PR DESCRIPTION
It came up in a previous discussion or issue (but I can't seem to find atm) that the HW will be stateful in dealing with the packet number (just like the real sender or receiver), and there is no reason to pass down the packet number per send. So this PR makes the following changes:

- Removes packet number of TX ancillary data
- Adds packet number to connection offload data
  - This essentially indicates the "starting point" for the offloads stateful logic, and will be updated as it processes TX/RX packets.